### PR TITLE
Bump fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curlconverter/tree-sitter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Incremental parsers for node",
   "author": "Max Brunsfeld",
   "license": "MIT",


### PR DESCRIPTION
The first time you `npm publish` you need to do `npm publish --access=public`. This 0.0.2 release will be the same but will be released through GitHub Actions.