### PR TITLE
Use correct msvs language standard format

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -29,7 +29,7 @@
         ['OS == "win"', {
           "msbuild_settings": {
             "ClCompile": {
-              "LanguageStandard": "stdcpp17"
+              "LanguageStandard": "/std:c++17"
             }
           }
         }]


### PR DESCRIPTION
Give this a shot. Note the `/` instead of `-` in `/std:c++17`.

https://github.com/verhovsky/node-tree-sitter/blob/c02fbb635a3b53969997ac56f8ac8144bf2250c6/binding.gyp#L32